### PR TITLE
各関数の調整

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,13 +1,5 @@
-// basic.showLeds(`
-//     . . . . .
-//     . # . # .
-//     . . . . .
-//     # . . . #
-//     . # # # .
-//     `);
-
 /*
- * LED(digital):P0,P1
+ * LED(digital):P0(L),P1(R)
  * sound(PWM):P2
  * servo(PWM):P15(L), P16(R)
  */
@@ -28,30 +20,8 @@ const speakerPin = AnalogPin.P2;
 const servoLeftPin = AnalogPin.P15;
 const servoRightPin = AnalogPin.P16;
 
-//目の明るさ
-enum presetEyeBrightness {
-    //% block="ふつう"
-    usual = 500,
-    //% block="つよく"
-    strong = 1023,
-    //% block="よわく"
-    weak = 128
-}
-
-// 前後
-enum direction {
-    //% block="まえ"
-    forward = 1,
-    //% block="うしろ"
-    backward = -1,
-    //% block="ひだり"
-    left = -10,
-    //% block="みぎ"
-    right = 10
-}
-
 // 左右
-enum lr {
+enum direction {
     //% block="ひだり"
     left = -1,
     //% block="みぎ"
@@ -60,12 +30,12 @@ enum lr {
 
 //スピード
 enum presetSpeed {
-    //% block="ふつうに"
-    mid = 42,
-    //% block="はやく"
-    fast = 90,
     //% block="ゆっくり"
-    slow = 60
+    slow = 13,
+    //% block="ふつうに"
+    mid = 30,
+    //% block="はやく"
+    fast = 80,
     //% block="とまる"
     // stop = 0
 }
@@ -74,65 +44,44 @@ enum presetSpeed {
 enum presetSound {}
 
 //初期設定
-//スピーカー
-//P2を音声出力のピンに設定
-pins.analogSetPitchPin(speakerPin);
-music.setVolume(0);
-//スピーカーをPWM出力の対象から外す
-// pins.digitalWritePin(DigitalPin.P2, 0);
-//サーボモーター
-pins.servoWritePin(servoLeftPin, 90);
-pins.servoWritePin(servoRightPin, 90);
-pins.analogWritePin(servoLeftPin, 0);
-pins.analogWritePin(servoRightPin, 0);
-//LED
-let eyeBrightness = presetEyeBrightness.usual;
-RobotZoo.openEyes();
+function init(){
+    //スピーカー
+    //P2を音声出力のピンに設定
+    pins.analogSetPitchPin(speakerPin);
+    music.setVolume(255);
+    //サーボモーター
+    pins.servoWritePin(AnalogPin.P15, 90);
+    pins.servoWritePin(AnalogPin.P16, 90);
+    pins.analogWritePin(servoLeftPin, 0);
+    pins.analogWritePin(servoRightPin, 0);
+    //LED
+    RobotZoo.openEyes();
+    basic.pause(300);
+}
 
-
+init();
 //% block="ロボット動物園"
 //% weight=200 color=#ff8308 icon=""
-//% groups="['かんさつ','つくる']"
+//% groups="['つくる','かんさつ']"
 
-/*********************
- *ロボット動物園#2 仕様
- *動きサンプル以外を隠す
- * //% block=""
- *********************/
 //つくる
 namespace RobotZoo {
-    function setServoSpeed(_speed: presetSpeed, _dir:direction){
-        let spL = 90 - _speed * _dir;
-        let spR = 90 + _speed * _dir;
-        pins.servoWritePin(servoLeftPin, spL);
-        pins.servoWritePin(servoRightPin, spR);
-    }
-
-    function setServolr(_speed: presetSpeed, _lr:lr){
-        let spL = 90 - _speed * _lr;
-        let spR = 90 - _speed * _lr;
-        pins.servoWritePin(servoLeftPin, spL);
-        pins.servoWritePin(servoRightPin, spR);
-    }
-
     /**
      * ロボットを指定した時間止める
      */
     //% block="じっとする : $_duration|ミリ秒"
-    //% _duration.shadow="timePicker" _duration.defl=500
+    //% _duration.shadow="timePicker"
+    //% _duration.defl=500
     //% group="つくる"
-    //% block="じっとする"
+    // block=""
     //% weight=550
-    export function keepStill(): void {
-        //スピーカーをPWM出力の対象から外す
-        // pins.digitalWritePin(DigitalPin.P2, 0);
-
+    export function keepStill(_duration: number): void {
         //サーボを設定
         pins.servoWritePin(servoLeftPin, 90);
         pins.servoWritePin(servoRightPin, 90);
         pins.analogWritePin(servoLeftPin, 0);
         pins.analogWritePin(servoRightPin, 0);
-        basic.pause(300);
+        basic.pause(_duration);
     }
 
     /**
@@ -141,18 +90,15 @@ namespace RobotZoo {
     //% block=" $_speed|まえにすすむ : $_duration|ミリ秒"
     //% _speed.min=0 _speed.max=100
     //% _duration.shadow="timePicker"
+    //% _duration.defl=500
     //% group="つくる"
     //% weight=1000
-    //% block=""
+    // block=""
     export function goStraigt(_speed: presetSpeed, _duration: number): void {
-        //スピーカーをPWM出力の対象から外す
-        // pins.digitalWritePin(DigitalPin.P2, 0);
-
-        //サーボを設定
-        // setServoSpeed(_speed, direction.forward);
-        pins.servoWritePin(servoLeftPin, 132);
-        pins.servoWritePin(servoRightPin, 48);
+        pins.servoWritePin(servoLeftPin, 90+_speed);
+        pins.servoWritePin(servoRightPin, 90-_speed);
         basic.pause(_duration);
+        keepStill(0);
     }
 
     /**
@@ -160,65 +106,60 @@ namespace RobotZoo {
      */
     //% block=" $_speed|うしろにさがる : $_duration|ミリ秒"
     //% _duration.shadow="timePicker"
+    //% _duration.defl=500
     //% group="つくる"
     //% weight=900
-    //% block=""
+    // block=""
     export function goBack(_speed: presetSpeed, _duration: number): void {
-        //スピーカーをPWM出力の対象から外す
-        // pins.digitalWritePin(DigitalPin.P2, 0);
-
-        //サーボを設定
-        //setServoSpeed(_speed, direction.backward);
-        pins.servoWritePin(servoLeftPin, 48);
-        pins.servoWritePin(servoRightPin, 132);
+        pins.servoWritePin(servoLeftPin, 90-_speed);
+        pins.servoWritePin(servoRightPin, 90+_speed);
         basic.pause(_duration);
+        keepStill(0);
     }
 
     /**
-     * ロボットが曲がる向きスピード、動く時間を決める
+     * ロボットが曲がる向き、スピード、動く時間を決める
      */
-    //% block="$_dir|にまがる : $_duration|ミリ秒"
+    //% block="$_speed|$_dir|にまがる : $_duration|ミリ秒"
     //% _duration.shadow="timePicker"
+    //% _duration.defl=500
     //% group="つくる"
     //% weight=800
-    //% block=""
-    export function turn(_dir: lr, _speed: presetSpeed, _duration: number): void {
-        //スピーカーをPWM出力の対象から外す
-        // pins.digitalWritePin(DigitalPin.P2, 0);
-
+    // block=""
+    export function turn(_dir: direction, _speed: presetSpeed, _duration: number): void {
         //サーボを設定
-        if(_dir==10){ //right
-            pins.servoWritePin(servoLeftPin, 132);
+        if(_dir==1){ //right
+            pins.servoWritePin(servoLeftPin, 90+_speed);
             pins.servoWritePin(servoRightPin, 90);
-        }else if(_dir==-10){ //left
-            pins.servoWritePin(servoLeftPin, 48);
-            pins.servoWritePin(servoRightPin, 90);
+            pins.analogWritePin(servoRightPin, 0);
+        }else if(_dir==-1){ //left
+            pins.servoWritePin(servoLeftPin, 90);
+            pins.analogWritePin(servoLeftPin, 0);
+            pins.servoWritePin(servoRightPin, 90-_speed);
         }
         basic.pause(_duration);
+        keepStill(0);
     }
 
     /**
      * ロボットがどちらに振り向くか、スピード、動く時間を決める
      */
-    //% block="$_lr|にふりむく : $_duration|ミリ秒"
+    //% block="$_speed|$_dir|にふりむく : $_duration|ミリ秒"
     //% _duration.shadow="timePicker"
+    //% _duration.defl=500
     //% group="つくる"
     //% weight=700
-    //% block=""
-    export function lookBack(_lr: lr, _speed: presetSpeed, _duration: number): void {
-        //スピーカーをPWM出力の対象から外す
-        // pins.digitalWritePin(DigitalPin.P2, 0);
-
-        //サーボを設定
-        // setServolr(_speed, _lr);
-        if(_lr==1){ //right
-            pins.servoWritePin(servoLeftPin, 132);
-            pins.servoWritePin(servoRightPin, 132);
-        }else if(_lr==-1){ //left
-            pins.servoWritePin(servoLeftPin, 48);
-            pins.servoWritePin(servoRightPin, 48);
+    // block=""
+    export function lookBack(_dir: direction, _speed: presetSpeed, _duration: number): void {
+        if(_dir==1){ //right
+            pins.servoWritePin(servoLeftPin, 90+_speed);
+            pins.servoWritePin(servoRightPin, 90+_speed);
+        }else if(_dir==-1){ //left
+            pins.servoWritePin(servoLeftPin, 90-_speed);
+            pins.servoWritePin(servoRightPin, 90-_speed);
         }
         basic.pause(_duration);
+        keepStill(0);
     }
 
     /**
@@ -226,23 +167,12 @@ namespace RobotZoo {
      */
     //% block="つづける : $_duration|ミリ秒間 "
     //% _duration.shadow="timePicker"
+    //% _duration.defl=500
     //% group="つくる"
     //% weight=600
-    //% block=""
+    // block=""
     export function keep(_duration: number): void {
         basic.pause(_duration);
-    }
-
-    /**
-     * ロボットの目の明るさを決める
-     */
-    //% block="めぢから : $_eBri"
-    //% group="つくる"
-    //% weight=500
-    //% block=""
-    export function setImpression(_eBri: presetEyeBrightness): void {
-        eyeBrightness = _eBri;
-        RobotZoo.openEyes();
     }
 
     /**
@@ -251,7 +181,7 @@ namespace RobotZoo {
     //% block="めをあける"
     //% group="つくる"
     //% weight=400
-    //% block=""
+    // block=""
     export function openEyes(): void {
         pins.digitalWritePin(ledLeftPin, 1);
         pins.digitalWritePin(ledRightPin, 1);
@@ -263,36 +193,52 @@ namespace RobotZoo {
     //% block="めをつぶる"
     //% group="つくる"
     //% weight=300
-    //% block=""
+    // block=""
     export function closeEyes(): void {
         pins.digitalWritePin(ledLeftPin, 0);
         pins.digitalWritePin(ledRightPin, 0);
     }
 
     /**
-     * ロボットのまばたき
+     * ロボットのまばたきの回数、かける時間を決める
      */
-    //% block="まばたき"
+    //% block="$_duration|ミリ秒かけて$_count|回まばたきする "
+    //% _duration.shadow="timePicker"
+    //% _duration.defl=500
     //% group="つくる"
     //% weight=200
-    //% block=""
-    export function blink(): void {
-        RobotZoo.openEyes();
-        basic.pause(400);
-        RobotZoo.closeEyes();
-        basic.pause(200);
-        RobotZoo.openEyes();
+    // block=""
+    export function blink(_count:number, _duration: number): void {
+        let _elapse = _duration/(_count*2);
+        for(let i = 0; i < _count; i++) {
+            RobotZoo.closeEyes();
+            RobotZoo.keep(_elapse);
+            RobotZoo.openEyes();
+            RobotZoo.keep(_elapse);
+        }
     }
 
     /**
      * ウインクする
      */
-    //% block="$lr ウインク"
+    //% block="$_duration|ミリ秒かけて$_dir|めをウインクする"
+    //% _duration.shadow="timePicker"
+    //% _duration.defl=500
     //% group="つくる"
     //% weight=100
-    //% block=""
-    export function wink(_lr:number): void {
-
+    // block=""
+    export function wink(_dir:direction, _duration: number): void {
+        if(_dir==-1){ //left
+            pins.digitalWritePin(ledLeftPin, 0);
+            pins.digitalWritePin(ledRightPin, 1);
+        }else if(_dir==1){ //right
+            pins.digitalWritePin(ledLeftPin, 1);
+            pins.digitalWritePin(ledRightPin, 0);
+        }
+        RobotZoo.keep(_duration/2);
+        pins.digitalWritePin(ledLeftPin, 1);
+        pins.digitalWritePin(ledRightPin, 1);
+        RobotZoo.keep(_duration/2);
     }
 
     /**
@@ -304,11 +250,9 @@ namespace RobotZoo {
     //% weight=50
     //% block=""
     export function sound(_animal: presetSound, _duration: number): void {
-        //サーボをPWM出力の対象から外す
-        // pins.digitalWritePin(DigitalPin.P15, 0);
-        // pins.digitalWritePin(DigitalPin.P16, 0);
         //P2を音声出力のピンに設定
         pins.analogSetPitchPin(speakerPin);
+        music.setVolume(0);
         music.playMelody("C5 B A G F E D C ", 120);
         //スピーカーをPWM出力の対象から外す
         // pins.digitalWritePin(DigitalPin.P2, 0);

--- a/main.ts
+++ b/main.ts
@@ -31,11 +31,11 @@ enum direction {
 //スピード
 enum presetSpeed {
     //% block="ゆっくり"
-    slow = 13,
+    slow = 12,
     //% block="ふつうに"
-    mid = 30,
+    mid = 23,
     //% block="はやく"
-    fast = 80,
+    fast = 90,
     //% block="とまる"
     // stop = 0
 }
@@ -69,7 +69,7 @@ namespace RobotZoo {
     /**
      * ロボットを指定した時間止める
      */
-    //% block="じっとする : $_duration|ミリ秒"
+    //% block="$_duration|ミリ秒間　じっとする"
     //% _duration.shadow="timePicker"
     //% _duration.defl=500
     //% group="つくる"
@@ -87,7 +87,7 @@ namespace RobotZoo {
     /**
      * ロボットが進む向き、スピード、動く時間を決める
      */
-    //% block=" $_speed|まえにすすむ : $_duration|ミリ秒"
+    //% block="$_duration|ミリ秒で、$_speed|まえにすすむ"
     //% _speed.min=0 _speed.max=100
     //% _duration.shadow="timePicker"
     //% _duration.defl=500
@@ -104,7 +104,7 @@ namespace RobotZoo {
     /**
      * ロボットが下がる向き、スピード、動く時間を決める
      */
-    //% block=" $_speed|うしろにさがる : $_duration|ミリ秒"
+    //% block="$_duration|ミリ秒で、$_speed|うしろにさがる"
     //% _duration.shadow="timePicker"
     //% _duration.defl=500
     //% group="つくる"
@@ -120,7 +120,7 @@ namespace RobotZoo {
     /**
      * ロボットが曲がる向き、スピード、動く時間を決める
      */
-    //% block="$_speed|$_dir|にまがる : $_duration|ミリ秒"
+    //% block="$_duration|ミリ秒で、$_speed|$_dir|にまがる"
     //% _duration.shadow="timePicker"
     //% _duration.defl=500
     //% group="つくる"
@@ -144,7 +144,7 @@ namespace RobotZoo {
     /**
      * ロボットがどちらに振り向くか、スピード、動く時間を決める
      */
-    //% block="$_speed|$_dir|にふりむく : $_duration|ミリ秒"
+    //% block="$_duration|ミリ秒で、$_speed|$_dir|にふりむく"
     //% _duration.shadow="timePicker"
     //% _duration.defl=500
     //% group="つくる"
@@ -165,7 +165,7 @@ namespace RobotZoo {
     /**
      * 直前の動きを指定した時間続ける
      */
-    //% block="つづける : $_duration|ミリ秒間 "
+    //% block="$_duration|ミリ秒間 つづける"
     //% _duration.shadow="timePicker"
     //% _duration.defl=500
     //% group="つくる"
@@ -202,7 +202,7 @@ namespace RobotZoo {
     /**
      * ロボットのまばたきの回数、かける時間を決める
      */
-    //% block="$_duration|ミリ秒かけて$_count|回まばたきする "
+    //% block="$_duration|ミリ秒で、$_count|回まばたきする "
     //% _duration.shadow="timePicker"
     //% _duration.defl=500
     //% group="つくる"
@@ -221,7 +221,7 @@ namespace RobotZoo {
     /**
      * ウインクする
      */
-    //% block="$_duration|ミリ秒かけて$_dir|めをウインクする"
+    //% block="$_duration|ミリ秒かけて、$_dir|めをウインクする"
     //% _duration.shadow="timePicker"
     //% _duration.defl=500
     //% group="つくる"
@@ -254,8 +254,6 @@ namespace RobotZoo {
         pins.analogSetPitchPin(speakerPin);
         music.setVolume(0);
         music.playMelody("C5 B A G F E D C ", 120);
-        //スピーカーをPWM出力の対象から外す
-        // pins.digitalWritePin(DigitalPin.P2, 0);
     }
 
     //「ずっと」内でのメロディー再生用のフラグ

--- a/pxt.json
+++ b/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "pxt-robotzoo",
-    "version": "0.1.8",
+    "version": "0.1.9",
     "description": "ロボット動物園",
     "license": "MIT",
     "dependencies": {

--- a/pxt.json
+++ b/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "pxt-robotzoo",
-    "version": "0.1.7",
+    "version": "0.1.8",
     "description": "ロボット動物園",
     "license": "MIT",
     "dependencies": {

--- a/test.ts
+++ b/test.ts
@@ -1,21 +1,47 @@
 // tests go here; this will not be compiled when this package is used as a library
+//---- init ----
+basic.showIcon(IconNames.Happy)
+init()
+
 //---- main.ts ----
-RobotZoo.blink()
-RobotZoo.blink()
-RobotZoo.blink()
-RobotZoo.keepStill()
-RobotZoo.goStraigt(presetSpeed.mid, 500)
-RobotZoo.goBack(presetSpeed.mid, 500)
-RobotZoo.keepStill()
+RobotZoo.blink(3, 1800)
+for(let i = 0; i < 90; i++) {
+    pins.servoWritePin(servoLeftPin, 90+i)
+    pins.servoWritePin(servoRightPin, 90-i)
+    led.plotBarGraph(i, 90)
+    basic.pause(50)
+}
+for(let i = 90; i > 0; i--) {
+    pins.servoWritePin(servoLeftPin, 90+i)
+    pins.servoWritePin(servoRightPin, 90-i)
+    led.plotBarGraph(i, 90)
+    basic.pause(50)
+}
+RobotZoo.keepStill(500)
+
+led.plotBarGraph(presetSpeed.slow, 90)
+RobotZoo.goStraigt(presetSpeed.slow, 1000)
+RobotZoo.keepStill(500)
+led.plotBarGraph(presetSpeed.mid, 90)
+RobotZoo.goStraigt(presetSpeed.mid, 1000)
+RobotZoo.keepStill(500)
+led.plotBarGraph(presetSpeed.fast, 90)
+RobotZoo.goStraigt(presetSpeed.fast, 1000)
+RobotZoo.keepStill(500)
+led.plotBarGraph(presetSpeed.mid, 90)
+RobotZoo.goBack(presetSpeed.mid, 1000)
+RobotZoo.keepStill(500)
+
 //---- samples.ts ----
 RobotZoo.toddle()
-RobotZoo.keepStill()
+RobotZoo.keepStill(300)
 // RobotZoo.swift()
-// RobotZoo.keepStill()
+// RobotZoo.keepStill(300)
 RobotZoo.poke()
-RobotZoo.keepStill()
+RobotZoo.keepStill(300)
 RobotZoo.stroll()
-RobotZoo.keepStill()
+RobotZoo.keepStill(300)
 RobotZoo.lookAlound()
+RobotZoo.keepStill(300)
 // RobotZoo.rush()
-// RobotZoo.keepStill()
+// RobotZoo.keepStill(300)


### PR DESCRIPTION
- 各関数での速度、方向の設定方法を統一しました。

- 各動作の最後に「じっとする」を追加しました。プログラム的にあまり正しい表現とは言えませんが、ロボットが動き続けてしまうという「意図していない動作」を防止するためのものです。

- まばたき、ウインクの回数と時間を設定できるように変更しました。

- 各関数の時間設定の表記ゆれを統一しました。末尾にあったミリ秒を文頭に持ってくることで、何の時間を設定するのかをより理解しやすくしました。

  ex)
  - 300ミリ秒かけて、ゆっくり まえにすすむ
  - 500ミリ秒かけて、3回 まばたきする
「ゆっくり」「ふつうに」「はやく」で設定されるサーボモータの回転速度を調整しました。